### PR TITLE
PreferenceRepository 구현

### DIFF
--- a/login-assignment/login-assignment/Model/Data/DataError.swift
+++ b/login-assignment/login-assignment/Model/Data/DataError.swift
@@ -11,12 +11,14 @@ enum DataError: LocalizedError {
     case failedToCreateEntity(String)
     case coreDataEntityNotFound
     case failedToMap
+    case failedToFetchSignedInInfo
 
     var errorDescription: String? {
         switch self {
         case .failedToCreateEntity(let name): "Entity 생성에 실패했습니다. EntityName: \(name)"
         case .coreDataEntityNotFound: "Entity를 찾을 수 없습니다."
         case .failedToMap: "모델 매핑에 실패했습니다."
+        case .failedToFetchSignedInInfo: "로그인한 유저 정보를 읽어오지 못했습니다."
         }
     }
 }

--- a/login-assignment/login-assignment/Model/Data/UserDefaultsPreferenceRepository.swift
+++ b/login-assignment/login-assignment/Model/Data/UserDefaultsPreferenceRepository.swift
@@ -1,0 +1,45 @@
+//
+//  UserDefaultsPreferenceRepository.swift
+//  login-assignment
+//
+//  Created by 박진홍 on 6/11/25.
+//
+
+import Foundation
+
+final class UserDefaultsPreferenceRepository: PreferenceRepository {
+    let userDefaults: UserDefaults = UserDefaults.standard
+    
+    func hasSignedInBefore() -> Bool {
+        userDefaults.bool(forKey: PreferenceKey.isSignedIn)
+    }
+    
+    func saveSignedInUserInfo(_ info: SignedInDto) {
+        userDefaults.set(true, forKey: PreferenceKey.isSignedIn)
+        userDefaults.set(info.uuid.uuidString, forKey: PreferenceKey.id)
+        userDefaults.set(info.nickname, forKey: PreferenceKey.nickname)
+    }
+    
+    func fetchSignedInUserInfo() throws -> SignedInDto {
+        guard let uuidString: String = userDefaults.string(forKey: PreferenceKey.id),
+              let uuid: UUID = UUID(uuidString: uuidString),
+              let nickname: String = userDefaults.string(forKey: PreferenceKey.nickname)
+        else {
+            throw DataError.failedToFetchSignedInInfo
+        }
+        
+        return SignedInDto(uuid: uuid, nickname: nickname)
+    }
+    
+    func deleteSignedInUserInfo() {
+        userDefaults.removeObject(forKey: PreferenceKey.isSignedIn)
+        userDefaults.removeObject(forKey: PreferenceKey.id)
+        userDefaults.removeObject(forKey: PreferenceKey.nickname)
+    }
+}
+
+private enum PreferenceKey {
+    static let isSignedIn: String = "isSignedIn"
+    static let id: String = "uuid"
+    static let nickname: String = "nickname"
+}


### PR DESCRIPTION
## Overview
UserDefaults를 활용한 PreferenceRepository 구현
<!-- 무엇을, 왜 수정했는지 요약 -->

## Summary
- UserDefaults에 로그인 상태, uuid, nickname을 저장함
<!-- 주요 변경 포인트 정리 -->
<!-- 데이터 모델, 로직, ui 등 변경 요소별로 구분 -->

## Issue
- #11 
<!-- 관련 이슈 -->

## Review Point
- UUID 저장을 위해 uuidString 사용
- forKey에 이용할 상수를 private enum PreferenceKey에 저장
<!-- 꼭 검토해야 할 부분 -->
<!-- 의문점이나 논의 중인 부분 -->

## Test

<!-- 테스트 여부 -->

- [x] 빌드 테스트