### PR TITLE
fix: add missing email rule

### DIFF
--- a/login-assignment/login-assignment/Model/Domain/ValidationRules.swift
+++ b/login-assignment/login-assignment/Model/Domain/ValidationRules.swift
@@ -19,6 +19,9 @@ struct EmailRule {
         guard ValidationHelper.isStartWithLetter(text: localPart) else {
             return false
         }
+        guard ValidationHelper.isLowerCase(text: localPart) else {
+            return false
+        }
         return true
     }
 }
@@ -79,6 +82,15 @@ private enum ValidationHelper {
             return text.contains(regex)
         } catch {
             throw DomainError.failedToCreateRegex
+        }
+    }
+    
+    static func isLowerCase(text: String) -> Bool {
+        do {
+            let regex: Regex<Substring> = try Regex(#"^[a-z]+$"#)
+            return text.contains(regex)
+        } catch {
+            return false
         }
     }
 


### PR DESCRIPTION
Email의 local part가 소문자로만 이루어져야 하는 규칙 추가