### PR TITLE
유저 닉네임 표시 기능 추가

### DIFF
--- a/login-assignment/login-assignment/Model/Application/UseCase/UserInfoUseCase.swift
+++ b/login-assignment/login-assignment/Model/Application/UseCase/UserInfoUseCase.swift
@@ -1,0 +1,18 @@
+//
+//  UserInfoUseCase.swift
+//  login-assignment
+//
+//  Created by 박진홍 on 6/15/25.
+//
+
+final class UserInfoUseCase {
+    private let preferenceRepository: PreferenceRepository
+    
+    init(preferenceRepository: PreferenceRepository) {
+        self.preferenceRepository = preferenceRepository
+    }
+    
+    func getNickName() throws -> String {
+        try preferenceRepository.fetchSignedInUserInfo().nickname
+    }
+}

--- a/login-assignment/login-assignment/Presentation/Coordinator/AppCoordinator.swift
+++ b/login-assignment/login-assignment/Presentation/Coordinator/AppCoordinator.swift
@@ -34,10 +34,12 @@ final class AppCoordinator: Coordinator {
 
     private func showStartFlow() {
         let repository: PreferenceRepository = UserDefaultsPreferenceRepository()
-        let useCase: StartNavigationUseCase = StartNavigationUseCase(preferenceRepository: repository)
+        let navigateUseCase: StartNavigationUseCase = StartNavigationUseCase(preferenceRepository: repository)
+        let userInfoUseCase: UserInfoUseCase = UserInfoUseCase(preferenceRepository: repository)
         let startCoordinator: StartCoordinator = StartCoordinator(
             navigationController: navigationController,
-            useCase: useCase,
+            navigateUseCase: navigateUseCase,
+            userInfoUseCase: userInfoUseCase,
             coreDataStack: coreDataStack
         )
 

--- a/login-assignment/login-assignment/Presentation/SignInView/SignInViewModel.swift
+++ b/login-assignment/login-assignment/Presentation/SignInView/SignInViewModel.swift
@@ -10,6 +10,7 @@ import Combine
 @MainActor
 final class SignInViewModel {
     private let signInUseCase: SignInUseCase
+    private let userInfoUseCase: UserInfoUseCase
     private var cancellables: Set<AnyCancellable> = []
 
     @Published var email: String = ""
@@ -17,8 +18,8 @@ final class SignInViewModel {
     @Published private(set) var isLoading: Bool = false
 
     private let signInButtonSubject: PassthroughSubject<Void, Never> = PassthroughSubject<Void, Never>()
-    private let signInResultSubject: PassthroughSubject<Result<Void, Error>, Never> = {
-        PassthroughSubject<Result<Void, Error>, Never>()
+    private let signInResultSubject: PassthroughSubject<Result<String, Error>, Never> = {
+        PassthroughSubject<Result<String, Error>, Never>()
     }()
     private let navigateToSignUpSubject: PassthroughSubject<Void, Never> = {
         PassthroughSubject<Void, Never>()
@@ -27,7 +28,7 @@ final class SignInViewModel {
     var signInButtonPublisher: AnyPublisher<Void, Never> {
         signInButtonSubject.eraseToAnyPublisher()
     }
-    var signInResultPublisher: AnyPublisher<Result<Void, Error>, Never> {
+    var signInResultPublisher: AnyPublisher<Result<String, Error>, Never> {
         signInResultSubject.eraseToAnyPublisher()
     }
     var isSignInButtonEnabled: AnyPublisher<Bool, Never> {
@@ -47,8 +48,9 @@ final class SignInViewModel {
         navigateToSignUpSubject.eraseToAnyPublisher()
     }
 
-    init(useCase: SignInUseCase) {
-        self.signInUseCase = useCase
+    init(signInUseCase: SignInUseCase, userInfoUseCase: UserInfoUseCase) {
+        self.signInUseCase = signInUseCase
+        self.userInfoUseCase = userInfoUseCase
         bind()
     }
 
@@ -77,7 +79,7 @@ final class SignInViewModel {
             defer { self.isLoading = false }
             do {
                 try await signInUseCase.execute(email: email, password: password)
-                signInResultSubject.send(.success(()))
+                signInResultSubject.send(.success(try userInfoUseCase.getNickName()))
             } catch {
                 signInResultSubject.send(.failure(error))
             }

--- a/login-assignment/login-assignment/Presentation/StartView/StartViewModel.swift
+++ b/login-assignment/login-assignment/Presentation/StartView/StartViewModel.swift
@@ -11,26 +11,29 @@ import Foundation
 @MainActor
 final class StartViewModel {
     private let navigationUseCase: StartNavigationUseCase
+    private let userInfoUseCase: UserInfoUseCase
 
-    private let navigateToWelcomeSubject: PassthroughSubject<Void, Never> = PassthroughSubject<Void, Never>()
+    private let navigateToWelcomeSubject: PassthroughSubject<String, Never> = PassthroughSubject<String, Never>()
     private let navigateToSignInSubject: PassthroughSubject<Void, Never> = PassthroughSubject<Void, Never>()
 
-    var navigateToWelcomePublisher: AnyPublisher<Void, Never> {
+    var navigateToWelcomePublisher: AnyPublisher<String, Never> {
         navigateToWelcomeSubject.eraseToAnyPublisher()
     }
     var navigateToSignInPublisher: AnyPublisher<Void, Never> {
         navigateToSignInSubject.eraseToAnyPublisher()
     }
 
-    init(navigationUseCase: StartNavigationUseCase) {
+    init(navigationUseCase: StartNavigationUseCase, userInfoUseCase: UserInfoUseCase) {
         self.navigationUseCase = navigationUseCase
+        self.userInfoUseCase = userInfoUseCase
     }
 
     func startButtonTapped() {
-        if navigationUseCase.execute() {
-            navigateToWelcomeSubject.send()
-        } else {
+        guard navigationUseCase.execute(),
+              let name = try? userInfoUseCase.getNickName() else {
             navigateToSignInSubject.send()
+            return
         }
+        navigateToWelcomeSubject.send(name)
     }
 }

--- a/login-assignment/login-assignment/Presentation/WelcomeView/WelcomeUIView.swift
+++ b/login-assignment/login-assignment/Presentation/WelcomeView/WelcomeUIView.swift
@@ -10,10 +10,11 @@ import UIKit
 final class WelcomeUIView: UIView {
     var onSignOutButtonTapped: (() -> Void)?
     var onDeleteButtonTapped: (() -> Void)?
+    private let userName: String
 
     private let titleLabel: UILabel = {
         let label: UILabel = UILabel()
-        label.text = "Welcome!"
+        label.text = "Welcome user!"
         label.textAlignment = .center
         label.font = .systemFont(ofSize: UIMetric.FontSize.title)
         label.textColor = .black
@@ -50,8 +51,9 @@ final class WelcomeUIView: UIView {
         return button
     }()
 
-    override init(frame: CGRect) {
-        super.init(frame: frame)
+    init(name: String) {
+        self.userName = name
+        super.init(frame: .zero )
         setUpUI()
         setupConstraints()
         setupButtonAction()
@@ -71,6 +73,7 @@ final class WelcomeUIView: UIView {
         ].forEach {
             addSubview($0)
         }
+        self.titleLabel.text = "Welcome \(self.userName)!"
     }
 
     private func setupConstraints() {

--- a/login-assignment/login-assignment/Presentation/WelcomeView/WelcomeViewController.swift
+++ b/login-assignment/login-assignment/Presentation/WelcomeView/WelcomeViewController.swift
@@ -12,9 +12,11 @@ final class WelcomeViewController: UIViewController {
     private var contentView: WelcomeUIView!
     var cancellables: Set<AnyCancellable> = []
     private let viewModel: WelcomeViewModel
+    private let userName: String
 
-    init(viewModel: WelcomeViewModel) {
+    init(viewModel: WelcomeViewModel, name: String) {
         self.viewModel = viewModel
+        self.userName = name
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -23,7 +25,7 @@ final class WelcomeViewController: UIViewController {
     }
 
     override func loadView() {
-        contentView = WelcomeUIView()
+        contentView = WelcomeUIView(name: userName)
         view = contentView
     }
 


### PR DESCRIPTION
## Overview
- 로그인 성공 시 유저 이름을 전달하여 표시하는 기능 추가

## Review Point
- **UserInfoUseCase**와 `getNickname()` 추가
- **WelcomeView**, **ViewController** 수정
    - title label에 nickname 추가 및 전달
- **StartViewModel**, **SignInViewModel** 수정
    - UserInfoUseCase를 통해 닉네임 받아오기 및 퍼블리셔를 통해 코디네이터에 전달
- **StartCoordinator**, **AuthCoordinator** 수정
    - WelcomeView를 push할 때 닉네임 전달

## Next Steps
- 의존성 주입 정리 필요
    - 전달할 UseCase를 하나의 파라미터로 전달할 구조체 필요
    - Coordinator단에서 CoreDataStack을 알고 있어 Data 단과 연결된 문제 해결
        - Application에만 의존하도록 수정
        - CoreDataStack은 컴포지셔널 루트에서 처리
 

## Related Issue
- #29 

## Test
- [x] Build
- [x] UI